### PR TITLE
Move KeyValueIterable and KeyValueIterableView from trace to common

### DIFF
--- a/api/include/opentelemetry/common/key_value_iterable.h
+++ b/api/include/opentelemetry/common/key_value_iterable.h
@@ -5,7 +5,7 @@
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
-namespace trace
+namespace common
 {
 /**
  * Supports internal iteration over a collection of key-value pairs.
@@ -30,5 +30,5 @@ public:
    */
   virtual size_t size() const noexcept = 0;
 };
-}  // namespace trace
+}  // namespace common
 OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/common/key_value_iterable_view.h
+++ b/api/include/opentelemetry/common/key_value_iterable_view.h
@@ -4,12 +4,12 @@
 #include <type_traits>
 #include <utility>
 
+#include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/nostd/utility.h"
-#include "opentelemetry/trace/key_value_iterable.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
-namespace trace
+namespace common
 {
 namespace detail
 {
@@ -60,5 +60,5 @@ public:
 private:
   const T *container_;
 };
-}  // namespace trace
+}  // namespace common
 OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/metrics/async_instruments.h
+++ b/api/include/opentelemetry/metrics/async_instruments.h
@@ -28,7 +28,7 @@ public:
    * @param value is the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override = 0;
+  virtual void observe(T value, const common::KeyValueIterable &labels) override = 0;
 
   /**
    * Captures data by activating the callback function associated with the
@@ -55,7 +55,7 @@ public:
               void (*callback)(ObserverResult<T>))
   {}
 
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override = 0;
+  virtual void observe(T value, const common::KeyValueIterable &labels) override = 0;
 
   virtual void run() override = 0;
 };
@@ -74,7 +74,7 @@ public:
                     void (*callback)(ObserverResult<T>))
   {}
 
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override = 0;
+  virtual void observe(T value, const common::KeyValueIterable &labels) override = 0;
 
   virtual void run() override = 0;
 };

--- a/api/include/opentelemetry/metrics/instrument.h
+++ b/api/include/opentelemetry/metrics/instrument.h
@@ -2,9 +2,9 @@
 
 #include <iostream>
 #include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
-#include "opentelemetry/trace/key_value_iterable_view.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace metrics
@@ -135,7 +135,7 @@ public:
    * @return a Bound Instrument
    */
   virtual nostd::shared_ptr<BoundSynchronousInstrument<T>> bind(
-      const trace::KeyValueIterable &labels)
+      const common::KeyValueIterable &labels)
   {
     return nostd::shared_ptr<BoundSynchronousInstrument<T>>();
   }
@@ -152,7 +152,7 @@ public:
    * @param value is the numerical representation of the metric being captured
    * @return void
    */
-  virtual void update(T value, const trace::KeyValueIterable &labels) = 0;
+  virtual void update(T value, const common::KeyValueIterable &labels) = 0;
 };
 
 template <class T>
@@ -181,7 +181,7 @@ public:
    * @param labels is the numerical representation of the metric being captured
    * @return none
    */
-  virtual void observe(T value, const trace::KeyValueIterable &labels) = 0;
+  virtual void observe(T value, const common::KeyValueIterable &labels) = 0;
 
   /**
    * Captures data by activating the callback function associated with the

--- a/api/include/opentelemetry/metrics/meter.h
+++ b/api/include/opentelemetry/metrics/meter.h
@@ -263,19 +263,19 @@ public:
    * @param values a span of values to record to the instruments in the corresponding
    * position in the instruments span.
    */
-  virtual void RecordShortBatch(const trace::KeyValueIterable &labels,
+  virtual void RecordShortBatch(const common::KeyValueIterable &labels,
                                 nostd::span<SynchronousInstrument<short> *> instruments,
                                 nostd::span<const short> values) noexcept = 0;
 
-  virtual void RecordIntBatch(const trace::KeyValueIterable &labels,
+  virtual void RecordIntBatch(const common::KeyValueIterable &labels,
                               nostd::span<SynchronousInstrument<int> *> instruments,
                               nostd::span<const int> values) noexcept = 0;
 
-  virtual void RecordFloatBatch(const trace::KeyValueIterable &labels,
+  virtual void RecordFloatBatch(const common::KeyValueIterable &labels,
                                 nostd::span<SynchronousInstrument<float> *> instruments,
                                 nostd::span<const float> values) noexcept = 0;
 
-  virtual void RecordDoubleBatch(const trace::KeyValueIterable &labels,
+  virtual void RecordDoubleBatch(const common::KeyValueIterable &labels,
                                  nostd::span<SynchronousInstrument<double> *> instruments,
                                  nostd::span<const double> values) noexcept = 0;
 };

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -38,7 +38,7 @@ public:
 
   virtual nostd::string_view GetUnits() override { return nostd::string_view(""); }
 
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override {}
+  virtual void observe(T value, const common::KeyValueIterable &labels) override {}
 
   virtual void run() override {}
 
@@ -65,7 +65,7 @@ public:
 
   virtual nostd::string_view GetUnits() override { return nostd::string_view(""); }
 
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override {}
+  virtual void observe(T value, const common::KeyValueIterable &labels) override {}
 
   virtual void run() override {}
 
@@ -92,7 +92,7 @@ public:
 
   virtual nostd::string_view GetUnits() override { return nostd::string_view(""); }
 
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override {}
+  virtual void observe(T value, const common::KeyValueIterable &labels) override {}
 
   virtual void run() override {}
 
@@ -138,14 +138,15 @@ public:
               bool /*enabled*/)
   {}
 
-  nostd::shared_ptr<BoundNoopCounter<T>> bindNoopCounter(const trace::KeyValueIterable & /*labels*/)
+  nostd::shared_ptr<BoundNoopCounter<T>> bindNoopCounter(
+      const common::KeyValueIterable & /*labels*/)
   {
     return nostd::shared_ptr<BoundNoopCounter<T>>(new BoundNoopCounter<T>());
   }
 
-  virtual void add(T value, const trace::KeyValueIterable & /*labels*/) override {}
+  virtual void add(T value, const common::KeyValueIterable & /*labels*/) override {}
 
-  virtual void update(T value, const trace::KeyValueIterable & /*labels*/) override {}
+  virtual void update(T value, const common::KeyValueIterable & /*labels*/) override {}
 
   virtual bool IsEnabled() override { return false; }
 
@@ -198,14 +199,14 @@ public:
   {}
 
   nostd::shared_ptr<BoundNoopUpDownCounter<T>> bindNoopUpDownCounter(
-      const trace::KeyValueIterable & /*labels*/)
+      const common::KeyValueIterable & /*labels*/)
   {
     return nostd::shared_ptr<BoundNoopUpDownCounter<T>>(new BoundNoopUpDownCounter<T>());
   }
 
-  virtual void add(T value, const trace::KeyValueIterable & /*labels*/) override {}
+  virtual void add(T value, const common::KeyValueIterable & /*labels*/) override {}
 
-  virtual void update(T value, const trace::KeyValueIterable & /*labels*/) override {}
+  virtual void update(T value, const common::KeyValueIterable & /*labels*/) override {}
 
   virtual bool IsEnabled() override { return false; }
 
@@ -258,14 +259,14 @@ public:
   {}
 
   nostd::shared_ptr<BoundNoopValueRecorder<T>> bindNoopValueRecorder(
-      const trace::KeyValueIterable & /*labels*/)
+      const common::KeyValueIterable & /*labels*/)
   {
     return nostd::shared_ptr<BoundNoopValueRecorder<T>>(new BoundNoopValueRecorder<T>());
   }
 
-  virtual void record(T value, const trace::KeyValueIterable & /*labels*/) override {}
+  virtual void record(T value, const common::KeyValueIterable & /*labels*/) override {}
 
-  virtual void update(T value, const trace::KeyValueIterable & /*labels*/) override {}
+  virtual void update(T value, const common::KeyValueIterable & /*labels*/) override {}
 
   virtual bool IsEnabled() override { return false; }
 
@@ -602,28 +603,28 @@ public:
    * @param instrs the instruments to record to.
    * @param values the value to record to those instruments.
    */
-  void RecordShortBatch(const trace::KeyValueIterable &labels,
+  void RecordShortBatch(const common::KeyValueIterable &labels,
                         nostd::span<SynchronousInstrument<short> *> instruments,
                         nostd::span<const short> values) noexcept override
   {
     // No-op
   }
 
-  void RecordIntBatch(const trace::KeyValueIterable &labels,
+  void RecordIntBatch(const common::KeyValueIterable &labels,
                       nostd::span<SynchronousInstrument<int> *> instruments,
                       nostd::span<const int> values) noexcept override
   {
     // No-op
   }
 
-  void RecordFloatBatch(const trace::KeyValueIterable &labels,
+  void RecordFloatBatch(const common::KeyValueIterable &labels,
                         nostd::span<SynchronousInstrument<float> *> instruments,
                         nostd::span<const float> values) noexcept override
   {
     // No-op
   }
 
-  void RecordDoubleBatch(const trace::KeyValueIterable &labels,
+  void RecordDoubleBatch(const common::KeyValueIterable &labels,
                          nostd::span<SynchronousInstrument<double> *> instruments,
                          nostd::span<const double> values) noexcept override
   {

--- a/api/include/opentelemetry/metrics/observer_result.h
+++ b/api/include/opentelemetry/metrics/observer_result.h
@@ -23,7 +23,7 @@ public:
 
   ObserverResult(AsynchronousInstrument<T> *instrument) : instrument_(instrument) {}
 
-  virtual void observe(T value, const trace::KeyValueIterable &labels)
+  virtual void observe(T value, const common::KeyValueIterable &labels)
   {
     instrument_->observe(value, labels);
   }

--- a/api/include/opentelemetry/metrics/sync_instruments.h
+++ b/api/include/opentelemetry/metrics/sync_instruments.h
@@ -48,7 +48,7 @@ public:
    * @param labels the set of labels, as key-value pairs.
    * @return a BoundIntCounter tied to the specified labels
    */
-  virtual nostd::shared_ptr<BoundCounter<T>> bindCounter(const trace::KeyValueIterable &labels)
+  virtual nostd::shared_ptr<BoundCounter<T>> bindCounter(const common::KeyValueIterable &labels)
   {
     return nostd::shared_ptr<BoundCounter<T>>();
   }
@@ -61,9 +61,9 @@ public:
    * @param value the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  virtual void add(T value, const trace::KeyValueIterable &labels) = 0;
+  virtual void add(T value, const common::KeyValueIterable &labels) = 0;
 
-  virtual void update(T value, const trace::KeyValueIterable &labels) override = 0;
+  virtual void update(T value, const common::KeyValueIterable &labels) override = 0;
 };
 
 template <class T>
@@ -101,7 +101,7 @@ public:
                 bool enabled);
 
   virtual nostd::shared_ptr<BoundUpDownCounter<T>> bindUpDownCounter(
-      const trace::KeyValueIterable &labels)
+      const common::KeyValueIterable &labels)
   {
     return nostd::shared_ptr<BoundUpDownCounter<T>>();
   }
@@ -114,9 +114,9 @@ public:
    * @param value the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  virtual void add(T value, const trace::KeyValueIterable &labels) = 0;
+  virtual void add(T value, const common::KeyValueIterable &labels) = 0;
 
-  virtual void update(T value, const trace::KeyValueIterable &labels) override = 0;
+  virtual void update(T value, const common::KeyValueIterable &labels) override = 0;
 };
 
 template <class T>
@@ -154,7 +154,7 @@ public:
                 bool enabled);
 
   virtual nostd::shared_ptr<BoundValueRecorder<T>> bindValueRecorder(
-      const trace::KeyValueIterable &labels)
+      const common::KeyValueIterable &labels)
   {
     return nostd::shared_ptr<BoundValueRecorder<T>>();
   }
@@ -167,9 +167,9 @@ public:
    * @param value the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  virtual void record(T value, const trace::KeyValueIterable &labels) = 0;
+  virtual void record(T value, const common::KeyValueIterable &labels) = 0;
 
-  virtual void update(T value, const trace::KeyValueIterable &labels) override = 0;
+  virtual void update(T value, const common::KeyValueIterable &labels) override = 0;
 };
 
 }  // namespace metrics

--- a/api/include/opentelemetry/plugin/tracer.h
+++ b/api/include/opentelemetry/plugin/tracer.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/plugin/detail/dynamic_library_handle.h"
 #include "opentelemetry/plugin/detail/tracer_handle.h"
 #include "opentelemetry/trace/tracer.h"
@@ -32,7 +33,7 @@ public:
 
   void AddEvent(nostd::string_view name,
                 core::SystemTimestamp timestamp,
-                const trace::KeyValueIterable &attributes) noexcept override
+                const common::KeyValueIterable &attributes) noexcept override
   {
     span_->AddEvent(name, timestamp, attributes);
   }
@@ -66,7 +67,7 @@ public:
   // trace::Tracer
   nostd::shared_ptr<trace::Span> StartSpan(
       nostd::string_view name,
-      const trace::KeyValueIterable &attributes,
+      const common::KeyValueIterable &attributes,
       const trace::StartSpanOptions &options = {}) noexcept override
   {
     auto span = tracer_handle_->tracer().StartSpan(name, attributes, options);

--- a/api/include/opentelemetry/trace/default_span.h
+++ b/api/include/opentelemetry/trace/default_span.h
@@ -25,10 +25,10 @@ public:
 
   void AddEvent(nostd::string_view name,
                 core::SystemTimestamp timestamp,
-                const KeyValueIterable &attributes) noexcept
+                const common::KeyValueIterable &attributes) noexcept
   {}
 
-  void AddEvent(nostd::string_view name, const KeyValueIterable &attributes) noexcept
+  void AddEvent(nostd::string_view name, const common::KeyValueIterable &attributes) noexcept
   {
     this->AddEvent(name, std::chrono::system_clock::now(), attributes);
   }

--- a/api/include/opentelemetry/trace/default_tracer.h
+++ b/api/include/opentelemetry/trace/default_tracer.h
@@ -21,7 +21,7 @@ public:
    * key will be overwritten.
    */
   nostd::unique_ptr<Span> StartSpan(nostd::string_view name,
-                                    const KeyValueIterable &attributes,
+                                    const common::KeyValueIterable &attributes,
                                     const StartSpanOptions &options = {}) override noexcept
   {
     return nostd::unique_ptr<Span>(new DefaultSpan::GetInvalid());

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -39,7 +39,7 @@ public:
 
   void AddEvent(nostd::string_view /*name*/,
                 core::SystemTimestamp /*timestamp*/,
-                const trace::KeyValueIterable & /*attributes*/) noexcept override
+                const common::KeyValueIterable & /*attributes*/) noexcept override
   {}
 
   void SetStatus(CanonicalCode /*code*/, nostd::string_view /*description*/) noexcept override {}
@@ -65,7 +65,7 @@ class NoopTracer final : public Tracer, public std::enable_shared_from_this<Noop
 public:
   // Tracer
   nostd::shared_ptr<Span> StartSpan(nostd::string_view /*name*/,
-                                    const KeyValueIterable & /*attributes*/,
+                                    const common::KeyValueIterable & /*attributes*/,
                                     const StartSpanOptions & /*options*/) noexcept override
   {
     // Don't allocate a no-op span for every StartSpan call, but use a static

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -16,13 +16,13 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/context/context.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/trace/default_span.h"
-#include "opentelemetry/trace/key_value_iterable.h"
 #include "opentelemetry/trace/propagation/http_text_format.h"
 #include "opentelemetry/trace/span.h"
 #include "opentelemetry/trace/span_context.h"

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -3,12 +3,12 @@
 #include <cstdint>
 
 #include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
 #include "opentelemetry/core/timestamp.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/unique_ptr.h"
 #include "opentelemetry/trace/canonical_code.h"
-#include "opentelemetry/trace/key_value_iterable_view.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/version.h"
 
@@ -100,25 +100,28 @@ public:
   // Adds an event to the Span, with a custom timestamp, and attributes.
   virtual void AddEvent(nostd::string_view name,
                         core::SystemTimestamp timestamp,
-                        const KeyValueIterable &attributes) noexcept = 0;
+                        const common::KeyValueIterable &attributes) noexcept = 0;
 
-  virtual void AddEvent(nostd::string_view name, const KeyValueIterable &attributes) noexcept
+  virtual void AddEvent(nostd::string_view name,
+                        const common::KeyValueIterable &attributes) noexcept
   {
     this->AddEvent(name, std::chrono::system_clock::now(), attributes);
   }
 
-  template <class T, nostd::enable_if_t<detail::is_key_value_iterable<T>::value> * = nullptr>
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
   void AddEvent(nostd::string_view name,
                 core::SystemTimestamp timestamp,
                 const T &attributes) noexcept
   {
-    this->AddEvent(name, timestamp, KeyValueIterableView<T>{attributes});
+    this->AddEvent(name, timestamp, common::KeyValueIterableView<T>{attributes});
   }
 
-  template <class T, nostd::enable_if_t<detail::is_key_value_iterable<T>::value> * = nullptr>
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
   void AddEvent(nostd::string_view name, const T &attributes) noexcept
   {
-    this->AddEvent(name, KeyValueIterableView<T>{attributes});
+    this->AddEvent(name, common::KeyValueIterableView<T>{attributes});
   }
 
   void AddEvent(nostd::string_view name,

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -32,7 +32,7 @@ public:
    * key will be overwritten.
    */
   virtual nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
-                                            const KeyValueIterable &attributes,
+                                            const common::KeyValueIterable &attributes,
                                             const StartSpanOptions &options = {}) noexcept = 0;
 
   nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
@@ -41,12 +41,13 @@ public:
     return this->StartSpan(name, {}, options);
   }
 
-  template <class T, nostd::enable_if_t<detail::is_key_value_iterable<T>::value> * = nullptr>
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
   nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
                                     const T &attributes,
                                     const StartSpanOptions &options = {}) noexcept
   {
-    return this->StartSpan(name, KeyValueIterableView<T>(attributes), options);
+    return this->StartSpan(name, common::KeyValueIterableView<T>(attributes), options);
   }
 
   nostd::shared_ptr<Span> StartSpan(

--- a/api/test/metrics/noop_instrument_test.cc
+++ b/api/test/metrics/noop_instrument_test.cc
@@ -11,7 +11,7 @@ namespace metrics
 void noopIntCallback(ObserverResult<int> result)
 {
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   result.observe(1, labelkv);
   result.observe(-1, labelkv);
 }
@@ -19,7 +19,7 @@ void noopIntCallback(ObserverResult<int> result)
 void noopDoubleCallback(ObserverResult<double> result)
 {
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   result.observe(1.5, labelkv);
   result.observe(-1.5, labelkv);
 }
@@ -31,7 +31,7 @@ TEST(ValueObserver, Observe)
   NoopValueObserver<double> beta("test", "none", "unitless", true, &noopDoubleCallback);
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.observe(1, labelkv);
   beta.observe(1.5, labelkv);
@@ -44,7 +44,7 @@ TEST(SumObserver, DefaultConstruction)
   NoopSumObserver<double> beta("test", "none", "unitless", true, &noopDoubleCallback);
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.observe(1, labelkv);
   beta.observe(1.5, labelkv);
@@ -57,7 +57,7 @@ TEST(UpDownSumObserver, DefaultConstruction)
   NoopUpDownSumObserver<double> beta("test", "none", "unitless", true, &noopDoubleCallback);
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.observe(1, labelkv);
   beta.observe(1.0, labelkv);
@@ -71,7 +71,7 @@ TEST(Counter, DefaultConstruction)
   NoopCounter<double> beta("other", "none", "unitless", true);
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.bind(labelkv);
 
@@ -88,7 +88,7 @@ TEST(Counter, Add)
   NoopCounter<double> beta("other", "none", "unitless", true);
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.add(1, labelkv);
   beta.add(1.5, labelkv);
@@ -109,7 +109,7 @@ TEST(UpDownCounter, DefaultConstruction)
   NoopUpDownCounter<double> beta("other", "none", "unitless", true);
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.bind(labelkv);
 
@@ -126,7 +126,7 @@ TEST(UpDownCounter, Add)
   NoopUpDownCounter<double> beta("other", "none", "unitless", true);
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.add(1, labelkv);
   beta.add(1.5, labelkv);
@@ -149,7 +149,7 @@ TEST(ValueRecorder, DefaultConstruction)
   NoopValueRecorder<double> beta("other", "none", "unitless", true);
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.bind(labelkv);
 
@@ -166,7 +166,7 @@ TEST(ValueRecorder, Record)
   NoopValueRecorder<double> beta("other", "none", "unitless", true);
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.record(1, labelkv);
   beta.record(1.5, labelkv);

--- a/api/test/metrics/noop_metrics_test.cc
+++ b/api/test/metrics/noop_metrics_test.cc
@@ -17,7 +17,7 @@ namespace metrics_api = opentelemetry::metrics;
 void Callback(opentelemetry::metrics::ObserverResult<int> result)
 {
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   result.observe(1, labelkv);
 }
 
@@ -43,7 +43,7 @@ TEST(NoopMeter, RecordBatch)
   std::unique_ptr<Meter> m{std::unique_ptr<Meter>(new NoopMeter{})};
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
 
   auto s = m->NewShortCounter("Test short counter", "For testing", "Unitless", true);
 

--- a/api/test/trace/key_value_iterable_view_test.cc
+++ b/api/test/trace/key_value_iterable_view_test.cc
@@ -1,4 +1,4 @@
-#include "opentelemetry/trace/key_value_iterable_view.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
 
 #include <gtest/gtest.h>
 #include <map>
@@ -6,7 +6,7 @@
 
 using namespace opentelemetry;
 
-static int TakeKeyValues(const trace::KeyValueIterable &iterable)
+static int TakeKeyValues(const common::KeyValueIterable &iterable)
 {
   std::map<std::string, common::AttributeValue> result;
   int count = 0;
@@ -17,27 +17,27 @@ static int TakeKeyValues(const trace::KeyValueIterable &iterable)
   return count;
 }
 
-template <class T, nostd::enable_if_t<trace::detail::is_key_value_iterable<T>::value> * = nullptr>
+template <class T, nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
 static int TakeKeyValues(const T &iterable)
 {
-  return TakeKeyValues(trace::KeyValueIterableView<T>{iterable});
+  return TakeKeyValues(common::KeyValueIterableView<T>{iterable});
 }
 
 TEST(KeyValueIterableViewTest, is_key_value_iterable)
 {
   using M1 = std::map<std::string, std::string>;
-  EXPECT_TRUE(bool{trace::detail::is_key_value_iterable<M1>::value});
+  EXPECT_TRUE(bool{common::detail::is_key_value_iterable<M1>::value});
 
   using M2 = std::map<std::string, int>;
-  EXPECT_TRUE(bool{trace::detail::is_key_value_iterable<M2>::value});
+  EXPECT_TRUE(bool{common::detail::is_key_value_iterable<M2>::value});
 
   using M3 = std::map<std::string, common::AttributeValue>;
-  EXPECT_TRUE(bool{trace::detail::is_key_value_iterable<M3>::value});
+  EXPECT_TRUE(bool{common::detail::is_key_value_iterable<M3>::value});
 
   struct A
   {};
   using M4 = std::map<std::string, A>;
-  EXPECT_FALSE(bool{trace::detail::is_key_value_iterable<M4>::value});
+  EXPECT_FALSE(bool{common::detail::is_key_value_iterable<M4>::value});
 }
 
 TEST(KeyValueIterableViewTest, ForEachKeyValue)
@@ -53,7 +53,7 @@ TEST(KeyValueIterableViewTest, ForEachKeyValueWithExit)
 {
   using M = std::map<std::string, std::string>;
   M m1    = {{"abc", "123"}, {"xyz", "456"}};
-  trace::KeyValueIterableView<M> iterable{m1};
+  common::KeyValueIterableView<M> iterable{m1};
   int count = 0;
   auto exit = iterable.ForEachKeyValue([&count](nostd::string_view /*key*/,
                                                 common::AttributeValue /*value*/) noexcept {

--- a/examples/metrics_simple/README.md
+++ b/examples/metrics_simple/README.md
@@ -33,7 +33,7 @@ shared_ptr<MetricsProcessor> processor = shared_ptr<MetricsProcessor>(new Ungrou
 // Observer callback function
 void SumObserverCallback(metrics_api::ObserverResult<int> result){
     std::map<std::string, std::string> labels = {{"key", "value"}};
-    auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
+    auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
     result.observe(1,labelkv);
 }
 
@@ -43,7 +43,7 @@ auto obs= meter->NewIntSumObserver("Counter","none", "none", true, &SumObserverC
 
 // Create a label set which annotates metric values
 std::map<std::string, std::string> labels = {{"key", "value"}};
-auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
+auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
 // Capture data from instruments.  Note that the asynchronous instrument is updates
 // automatically though its callback at the collection interval.  Additional measurments

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -7,7 +7,6 @@
 
 namespace sdkmetrics = opentelemetry::sdk::metrics;
 namespace nostd      = opentelemetry::nostd;
-namespace trace      = opentelemetry::trace;
 
 int main()
 {
@@ -33,7 +32,7 @@ int main()
 
   // Create a labelset
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
 
   // Create arrays of instrument and values to add to them
   metrics_api::SynchronousInstrument<int> *iinstr_arr[] = {intupdowncounter.get(),

--- a/examples/plugin/plugin/tracer.cc
+++ b/examples/plugin/plugin/tracer.cc
@@ -18,7 +18,7 @@ class Span final : public trace::Span
 public:
   Span(std::shared_ptr<Tracer> &&tracer,
        nostd::string_view name,
-       const opentelemetry::trace::KeyValueIterable & /*attributes*/,
+       const opentelemetry::common::KeyValueIterable & /*attributes*/,
        const trace::StartSpanOptions & /*options*/) noexcept
       : tracer_{std::move(tracer)}, name_{name}, span_context_{trace::SpanContext::GetInvalid()}
   {
@@ -39,7 +39,7 @@ public:
 
   void AddEvent(nostd::string_view /*name*/,
                 core::SystemTimestamp /*timestamp*/,
-                const trace::KeyValueIterable & /*attributes*/) noexcept override
+                const common::KeyValueIterable & /*attributes*/) noexcept override
   {}
 
   void SetStatus(trace::CanonicalCode /*code*/,
@@ -65,7 +65,7 @@ Tracer::Tracer(nostd::string_view /*output*/) {}
 
 nostd::shared_ptr<trace::Span> Tracer::StartSpan(
     nostd::string_view name,
-    const opentelemetry::trace::KeyValueIterable &attributes,
+    const opentelemetry::common::KeyValueIterable &attributes,
     const trace::StartSpanOptions &options) noexcept
 {
   return nostd::shared_ptr<opentelemetry::trace::Span>{

--- a/examples/plugin/plugin/tracer.h
+++ b/examples/plugin/plugin/tracer.h
@@ -13,7 +13,7 @@ public:
   // opentelemetry::trace::Tracer
   opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartSpan(
       opentelemetry::nostd::string_view name,
-      const opentelemetry::trace::KeyValueIterable & /*attributes*/,
+      const opentelemetry::common::KeyValueIterable & /*attributes*/,
       const opentelemetry::trace::StartSpanOptions & /*options */) noexcept override;
 
   void ForceFlushWithMicroseconds(uint64_t /*timeout*/) noexcept override {}

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -23,10 +23,10 @@ public:
 
   void AddEvent(nostd::string_view name,
                 core::SystemTimestamp timestamp,
-                const trace::KeyValueIterable &attributes) noexcept override;
+                const common::KeyValueIterable &attributes) noexcept override;
 
   void AddLink(opentelemetry::trace::SpanContext span_context,
-               const trace::KeyValueIterable &attributes) noexcept override;
+               const common::KeyValueIterable &attributes) noexcept override;
 
   void SetStatus(trace::CanonicalCode code, nostd::string_view description) noexcept override;
 

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -120,7 +120,7 @@ void Recordable::SetAttribute(nostd::string_view key,
 
 void Recordable::AddEvent(nostd::string_view name,
                           core::SystemTimestamp timestamp,
-                          const trace::KeyValueIterable &attributes) noexcept
+                          const common::KeyValueIterable &attributes) noexcept
 {
   auto *event = span_.add_events();
   event->set_name(name.data(), name.size());
@@ -133,7 +133,7 @@ void Recordable::AddEvent(nostd::string_view name,
 }
 
 void Recordable::AddLink(opentelemetry::trace::SpanContext span_context,
-                         const trace::KeyValueIterable &attributes) noexcept
+                         const common::KeyValueIterable &attributes) noexcept
 {
   auto *link = span_.add_links();
   attributes.ForEachKeyValue([&](nostd::string_view key, common::AttributeValue value) noexcept {

--- a/exporters/otlp/test/recordable_test.cc
+++ b/exporters/otlp/test/recordable_test.cc
@@ -105,7 +105,7 @@ TEST(Recordable, AddEventWithAttributes)
       {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
 
   rec.AddEvent("Test Event", std::chrono::system_clock::now(),
-               trace::KeyValueIterableView<std::map<std::string, int>>(attributes));
+               common::KeyValueIterableView<std::map<std::string, int>>(attributes));
 
   for (int i = 0; i < kNumAttributes; i++)
   {
@@ -124,7 +124,7 @@ TEST(Recordable, AddLink)
       {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
 
   rec.AddLink(trace::SpanContext(false, false),
-              trace::KeyValueIterableView<std::map<std::string, int>>(attributes));
+              common::KeyValueIterableView<std::map<std::string, int>>(attributes));
 
   for (int i = 0; i < kNumAttributes; i++)
   {

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -162,10 +162,10 @@ public:
     duration_ = duration;
   }
 
-  void AddLink(
-      opentelemetry::trace::SpanContext span_context,
-      const trace_api::KeyValueIterable &attributes =
-          trace_api::KeyValueIterableView<std::map<std::string, int>>({})) noexcept override
+  void AddLink(opentelemetry::trace::SpanContext span_context,
+               const opentelemetry::common::KeyValueIterable &attributes =
+                   opentelemetry::common::KeyValueIterableView<std::map<std::string, int>>(
+                       {})) noexcept override
   {
     std::lock_guard<std::mutex> lock(mutex_);
     (void)span_context;
@@ -175,8 +175,9 @@ public:
   void AddEvent(
       nostd::string_view name,
       core::SystemTimestamp timestamp = core::SystemTimestamp(std::chrono::system_clock::now()),
-      const trace_api::KeyValueIterable &attributes =
-          trace_api::KeyValueIterableView<std::map<std::string, int>>({})) noexcept override
+      const opentelemetry::common::KeyValueIterable &attributes =
+          opentelemetry::common::KeyValueIterableView<std::map<std::string, int>>(
+              {})) noexcept override
   {
     std::lock_guard<std::mutex> lock(mutex_);
     events_.push_back(SpanDataEvent(std::string(name), timestamp, attributes));

--- a/sdk/include/opentelemetry/sdk/common/empty_attributes.h
+++ b/sdk/include/opentelemetry/sdk/common/empty_attributes.h
@@ -1,4 +1,4 @@
-#include "opentelemetry/trace/key_value_iterable_view.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
 
 #include <array>
 #include <map>
@@ -13,11 +13,11 @@ namespace sdk
  * This helps to avoid constructing a new empty container every time a call is made
  * with default attributes.
  */
-static const opentelemetry::trace::KeyValueIterableView<std::array<std::pair<std::string, int>, 0>>
+static const opentelemetry::common::KeyValueIterableView<std::array<std::pair<std::string, int>, 0>>
     &GetEmptyAttributes() noexcept
 {
   static const std::array<std::pair<std::string, int>, 0> array{};
-  static const opentelemetry::trace::KeyValueIterableView<
+  static const opentelemetry::common::KeyValueIterableView<
       std::array<std::pair<std::string, int>, 0>>
       kEmptyAttributes(array);
 

--- a/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
@@ -46,7 +46,7 @@ public:
    * @param value is the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override
+  virtual void observe(T value, const common::KeyValueIterable &labels) override
   {
     this->mu_.lock();
     std::string labelset = KvToString(labels);
@@ -121,7 +121,7 @@ public:
    * @param value is the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override
+  virtual void observe(T value, const common::KeyValueIterable &labels) override
   {
     this->mu_.lock();
     std::string labelset = KvToString(labels);
@@ -219,7 +219,7 @@ public:
    * @param value is the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override
+  virtual void observe(T value, const common::KeyValueIterable &labels) override
   {
     this->mu_.lock();
     std::string labelset = KvToString(labels);

--- a/sdk/include/opentelemetry/sdk/metrics/controller.h
+++ b/sdk/include/opentelemetry/sdk/metrics/controller.h
@@ -14,7 +14,6 @@
 #include "opentelemetry/version.h"
 
 namespace metrics_api = opentelemetry::metrics;
-namespace trace_api   = opentelemetry::trace;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/instrument.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instrument.h
@@ -13,7 +13,6 @@
 #include "opentelemetry/version.h"
 
 namespace metrics_api = opentelemetry::metrics;
-namespace trace_api   = opentelemetry::trace;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -174,13 +173,13 @@ public:
    * @return a Bound Instrument
    */
   virtual nostd::shared_ptr<metrics_api::BoundSynchronousInstrument<T>> bind(
-      const trace::KeyValueIterable &labels) override
+      const common::KeyValueIterable &labels) override
   {
     return nostd::shared_ptr<BoundSynchronousInstrument<T>>();
   }
 
   // This function is necessary for batch recording and should NOT be called by the user
-  virtual void update(T value, const trace::KeyValueIterable &labels) override = 0;
+  virtual void update(T value, const common::KeyValueIterable &labels) override = 0;
 
   /**
    * Checkpoints instruments and returns a set of records which are ready for processing.
@@ -221,7 +220,7 @@ public:
    * @param labels is the numerical representation of the metric being captured
    * @return none
    */
-  virtual void observe(T value, const trace::KeyValueIterable &labels) override = 0;
+  virtual void observe(T value, const common::KeyValueIterable &labels) override = 0;
 
   virtual std::vector<Record> GetRecords() = 0;
 
@@ -236,7 +235,7 @@ public:
   virtual void run() override = 0;
 };
 
-// Helper functions for turning a trace::KeyValueIterable into a string
+// Helper functions for turning a common::KeyValueIterable into a string
 inline void print_value(std::stringstream &ss,
                         common::AttributeValue &value,
                         bool jsonTypes = false)
@@ -271,7 +270,7 @@ inline std::string mapToString(const std::map<std::string, std::string> &conv)
   return ss.str();
 }
 
-inline std::string KvToString(const trace::KeyValueIterable &kv) noexcept
+inline std::string KvToString(const common::KeyValueIterable &kv) noexcept
 {
   std::stringstream ss;
   ss << "{";

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -253,19 +253,19 @@ public:
    * @param values a span of pairs where the first element of the pair is a metric instrument
    * to record to, and the second element is the value to update that instrument with.
    */
-  void RecordShortBatch(const trace::KeyValueIterable &labels,
+  void RecordShortBatch(const common::KeyValueIterable &labels,
                         nostd::span<metrics_api::SynchronousInstrument<short> *> instruments,
                         nostd::span<const short> values) noexcept override;
 
-  void RecordIntBatch(const trace::KeyValueIterable &labels,
+  void RecordIntBatch(const common::KeyValueIterable &labels,
                       nostd::span<metrics_api::SynchronousInstrument<int> *> instruments,
                       nostd::span<const int> values) noexcept override;
 
-  void RecordFloatBatch(const trace::KeyValueIterable &labels,
+  void RecordFloatBatch(const common::KeyValueIterable &labels,
                         nostd::span<metrics_api::SynchronousInstrument<float> *> instruments,
                         nostd::span<const float> values) noexcept override;
 
-  void RecordDoubleBatch(const trace::KeyValueIterable &labels,
+  void RecordDoubleBatch(const common::KeyValueIterable &labels,
                          nostd::span<metrics_api::SynchronousInstrument<double> *> instruments,
                          nostd::span<const double> values) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
@@ -90,7 +90,7 @@ public:
    */
 
   virtual nostd::shared_ptr<metrics_api::BoundCounter<T>> bindCounter(
-      const trace::KeyValueIterable &labels) override
+      const common::KeyValueIterable &labels) override
   {
     this->mu_.lock();
     std::string labelset = KvToString(labels);
@@ -119,7 +119,7 @@ public:
    * @param value the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  virtual void add(T value, const trace::KeyValueIterable &labels) override
+  virtual void add(T value, const common::KeyValueIterable &labels) override
   {
     if (value < 0)
     {
@@ -163,7 +163,7 @@ public:
     return ret;
   }
 
-  virtual void update(T val, const trace::KeyValueIterable &labels) override { add(val, labels); }
+  virtual void update(T val, const common::KeyValueIterable &labels) override { add(val, labels); }
 
   // A collection of the bound instruments created by this unbound instrument identified by their
   // labels.
@@ -228,7 +228,7 @@ public:
    * @return a BoundIntCounter tied to the specified labels
    */
   nostd::shared_ptr<metrics_api::BoundUpDownCounter<T>> bindUpDownCounter(
-      const trace::KeyValueIterable &labels) override
+      const common::KeyValueIterable &labels) override
   {
     this->mu_.lock();
     std::string labelset = KvToString(labels);
@@ -257,7 +257,7 @@ public:
    * @param value the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  void add(T value, const trace::KeyValueIterable &labels) override
+  void add(T value, const common::KeyValueIterable &labels) override
   {
     auto sp = bindUpDownCounter(labels);
     sp->update(value);
@@ -290,7 +290,7 @@ public:
     return ret;
   }
 
-  virtual void update(T val, const trace::KeyValueIterable &labels) override { add(val, labels); }
+  virtual void update(T val, const common::KeyValueIterable &labels) override { add(val, labels); }
 
   std::unordered_map<std::string, nostd::shared_ptr<metrics_api::BoundUpDownCounter<T>>>
       boundInstruments_;
@@ -354,7 +354,7 @@ public:
    * @return a BoundIntCounter tied to the specified labels
    */
   nostd::shared_ptr<metrics_api::BoundValueRecorder<T>> bindValueRecorder(
-      const trace::KeyValueIterable &labels) override
+      const common::KeyValueIterable &labels) override
   {
     this->mu_.lock();
     std::string labelset = KvToString(labels);
@@ -383,7 +383,7 @@ public:
    * @param value the numerical representation of the metric being captured
    * @param labels the set of labels, as key-value pairs
    */
-  void record(T value, const trace::KeyValueIterable &labels) override
+  void record(T value, const common::KeyValueIterable &labels) override
   {
     auto sp = bindValueRecorder(labels);
     sp->update(value);
@@ -416,7 +416,7 @@ public:
     return ret;
   }
 
-  virtual void update(T value, const trace::KeyValueIterable &labels) override
+  virtual void update(T value, const common::KeyValueIterable &labels) override
   {
     record(value, labels);
   }

--- a/sdk/include/opentelemetry/sdk/trace/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/trace/attribute_utils.h
@@ -3,7 +3,7 @@
 #include <unordered_map>
 #include <vector>
 #include "opentelemetry/common/attribute_value.h"
-#include "opentelemetry/trace/key_value_iterable_view.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -94,7 +94,7 @@ public:
   AttributeMap(){};
 
   // Contruct attribute map and populate with attributes
-  AttributeMap(const opentelemetry::trace::KeyValueIterable &attributes)
+  AttributeMap(const opentelemetry::common::KeyValueIterable &attributes)
   {
     attributes.ForEachKeyValue([&](nostd::string_view key,
                                    opentelemetry::common::AttributeValue value) noexcept {

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/core/timestamp.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/common/empty_attributes.h"
 #include "opentelemetry/trace/canonical_code.h"
-#include "opentelemetry/trace/key_value_iterable.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/trace_id.h"
@@ -55,7 +55,7 @@ public:
    */
   virtual void AddEvent(nostd::string_view name,
                         core::SystemTimestamp timestamp,
-                        const trace_api::KeyValueIterable &attributes) noexcept = 0;
+                        const opentelemetry::common::KeyValueIterable &attributes) noexcept = 0;
 
   /**
    * Add an event to a span with default timestamp and attributes.
@@ -83,7 +83,7 @@ public:
    * @param attributes the attributes associated with the link
    */
   virtual void AddLink(opentelemetry::trace::SpanContext span_context,
-                       const trace_api::KeyValueIterable &attributes) noexcept = 0;
+                       const opentelemetry::common::KeyValueIterable &attributes) noexcept = 0;
 
   /**
    * Add a link to a span with default (empty) attributes.

--- a/sdk/include/opentelemetry/sdk/trace/sampler.h
+++ b/sdk/include/opentelemetry/sdk/trace/sampler.h
@@ -65,11 +65,12 @@ public:
    * @since 0.1.0
    */
 
-  virtual SamplingResult ShouldSample(const trace_api::SpanContext *parent_context,
-                                      trace_api::TraceId trace_id,
-                                      nostd::string_view name,
-                                      trace_api::SpanKind span_kind,
-                                      const trace_api::KeyValueIterable &attributes) noexcept = 0;
+  virtual SamplingResult ShouldSample(
+      const trace_api::SpanContext *parent_context,
+      trace_api::TraceId trace_id,
+      nostd::string_view name,
+      trace_api::SpanKind span_kind,
+      const opentelemetry::common::KeyValueIterable &attributes) noexcept = 0;
 
   /**
    * Returns the sampler name or short description with the configuration.

--- a/sdk/include/opentelemetry/sdk/trace/samplers/always_off.h
+++ b/sdk/include/opentelemetry/sdk/trace/samplers/always_off.h
@@ -19,11 +19,12 @@ public:
   /**
    * @return Returns DROP always
    */
-  SamplingResult ShouldSample(const trace_api::SpanContext * /*parent_context*/,
-                              trace_api::TraceId /*trace_id*/,
-                              nostd::string_view /*name*/,
-                              trace_api::SpanKind /*span_kind*/,
-                              const trace_api::KeyValueIterable & /*attributes*/) noexcept override
+  SamplingResult ShouldSample(
+      const trace_api::SpanContext * /*parent_context*/,
+      trace_api::TraceId /*trace_id*/,
+      nostd::string_view /*name*/,
+      trace_api::SpanKind /*span_kind*/,
+      const opentelemetry::common::KeyValueIterable & /*attributes*/) noexcept override
   {
     return {Decision::DROP, nullptr};
   }

--- a/sdk/include/opentelemetry/sdk/trace/samplers/always_on.h
+++ b/sdk/include/opentelemetry/sdk/trace/samplers/always_on.h
@@ -23,7 +23,7 @@ public:
       trace_api::TraceId /*trace_id*/,
       nostd::string_view /*name*/,
       trace_api::SpanKind /*span_kind*/,
-      const trace_api::KeyValueIterable & /*attributes*/) noexcept override
+      const opentelemetry::common::KeyValueIterable & /*attributes*/) noexcept override
   {
     return {Decision::RECORD_AND_SAMPLE, nullptr};
   }

--- a/sdk/include/opentelemetry/sdk/trace/samplers/parent_or_else.h
+++ b/sdk/include/opentelemetry/sdk/trace/samplers/parent_or_else.h
@@ -22,11 +22,12 @@ public:
    * delegateSampler for root spans
    * @return Returns DROP always
    */
-  SamplingResult ShouldSample(const trace_api::SpanContext *parent_context,
-                              trace_api::TraceId trace_id,
-                              nostd::string_view name,
-                              trace_api::SpanKind span_kind,
-                              const trace_api::KeyValueIterable &attributes) noexcept override;
+  SamplingResult ShouldSample(
+      const trace_api::SpanContext *parent_context,
+      trace_api::TraceId trace_id,
+      nostd::string_view name,
+      trace_api::SpanKind span_kind,
+      const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
 
   /**
    * @return Description MUST be ParentOrElse{delegate_sampler_.getDescription()}

--- a/sdk/include/opentelemetry/sdk/trace/samplers/probability.h
+++ b/sdk/include/opentelemetry/sdk/trace/samplers/probability.h
@@ -29,11 +29,12 @@ public:
    * is used as a pseudorandom value in conjunction with the predefined
    * threshold to determine whether this trace should be sampled
    */
-  SamplingResult ShouldSample(const trace_api::SpanContext *parent_context,
-                              trace_api::TraceId trace_id,
-                              nostd::string_view /*name*/,
-                              trace_api::SpanKind /*span_kind*/,
-                              const trace_api::KeyValueIterable & /*attributes*/) noexcept override;
+  SamplingResult ShouldSample(
+      const trace_api::SpanContext *parent_context,
+      trace_api::TraceId trace_id,
+      nostd::string_view /*name*/,
+      trace_api::SpanKind /*span_kind*/,
+      const opentelemetry::common::KeyValueIterable & /*attributes*/) noexcept override;
 
   /**
    * @return Description MUST be ProbabilitySampler{0.000100}

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -25,7 +25,7 @@ class SpanDataEvent
 public:
   SpanDataEvent(std::string name,
                 core::SystemTimestamp timestamp,
-                const trace_api::KeyValueIterable &attributes)
+                const opentelemetry::common::KeyValueIterable &attributes)
       : name_(name), timestamp_(timestamp), attribute_map_(attributes)
   {}
 
@@ -64,7 +64,7 @@ class SpanDataLink
 {
 public:
   SpanDataLink(opentelemetry::trace::SpanContext span_context,
-               const trace_api::KeyValueIterable &attributes)
+               const opentelemetry::common::KeyValueIterable &attributes)
       : span_context_(span_context), attribute_map_(attributes)
   {}
 
@@ -174,14 +174,14 @@ public:
 
   void AddEvent(nostd::string_view name,
                 core::SystemTimestamp timestamp,
-                const trace_api::KeyValueIterable &attributes) noexcept override
+                const opentelemetry::common::KeyValueIterable &attributes) noexcept override
   {
     SpanDataEvent event(std::string(name), timestamp, attributes);
     events_.push_back(event);
   }
 
   void AddLink(opentelemetry::trace::SpanContext span_context,
-               const trace_api::KeyValueIterable &attributes) noexcept override
+               const opentelemetry::common::KeyValueIterable &attributes) noexcept override
   {
     SpanDataLink link(span_context, attributes);
     links_.push_back(link);

--- a/sdk/include/opentelemetry/sdk/trace/tracer.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer.h
@@ -46,7 +46,7 @@ public:
 
   nostd::shared_ptr<trace_api::Span> StartSpan(
       nostd::string_view name,
-      const trace_api::KeyValueIterable &attributes,
+      const opentelemetry::common::KeyValueIterable &attributes,
       const trace_api::StartSpanOptions &options = {}) noexcept override;
 
   void ForceFlushWithMicroseconds(uint64_t timeout) noexcept override;

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -543,7 +543,7 @@ nostd::shared_ptr<metrics_api::ValueObserver<double>> Meter::NewDoubleValueObser
   return nostd::shared_ptr<metrics_api::ValueObserver<double>>(ptr);
 }
 
-void Meter::RecordShortBatch(const trace::KeyValueIterable &labels,
+void Meter::RecordShortBatch(const common::KeyValueIterable &labels,
                              nostd::span<metrics_api::SynchronousInstrument<short> *> instruments,
                              nostd::span<const short> values) noexcept
 {
@@ -553,7 +553,7 @@ void Meter::RecordShortBatch(const trace::KeyValueIterable &labels,
   }
 }
 
-void Meter::RecordIntBatch(const trace::KeyValueIterable &labels,
+void Meter::RecordIntBatch(const common::KeyValueIterable &labels,
                            nostd::span<metrics_api::SynchronousInstrument<int> *> instruments,
                            nostd::span<const int> values) noexcept
 {
@@ -563,7 +563,7 @@ void Meter::RecordIntBatch(const trace::KeyValueIterable &labels,
   }
 }
 
-void Meter::RecordFloatBatch(const trace::KeyValueIterable &labels,
+void Meter::RecordFloatBatch(const common::KeyValueIterable &labels,
                              nostd::span<metrics_api::SynchronousInstrument<float> *> instruments,
                              nostd::span<const float> values) noexcept
 {
@@ -573,7 +573,7 @@ void Meter::RecordFloatBatch(const trace::KeyValueIterable &labels,
   }
 }
 
-void Meter::RecordDoubleBatch(const trace::KeyValueIterable &labels,
+void Meter::RecordDoubleBatch(const common::KeyValueIterable &labels,
                               nostd::span<metrics_api::SynchronousInstrument<double> *> instruments,
                               nostd::span<const double> values) noexcept
 {

--- a/sdk/src/trace/samplers/parent_or_else.cc
+++ b/sdk/src/trace/samplers/parent_or_else.cc
@@ -15,7 +15,7 @@ SamplingResult ParentOrElseSampler::ShouldSample(
     trace_api::TraceId trace_id,
     nostd::string_view name,
     trace_api::SpanKind span_kind,
-    const trace_api::KeyValueIterable &attributes) noexcept
+    const opentelemetry::common::KeyValueIterable &attributes) noexcept
 {
   if (parent_context == nullptr)
   {

--- a/sdk/src/trace/samplers/probability.cc
+++ b/sdk/src/trace/samplers/probability.cc
@@ -88,7 +88,7 @@ SamplingResult ProbabilitySampler::ShouldSample(
     trace_api::TraceId trace_id,
     nostd::string_view /*name*/,
     trace_api::SpanKind /*span_kind*/,
-    const trace_api::KeyValueIterable & /*attributes*/) noexcept
+    const opentelemetry::common::KeyValueIterable & /*attributes*/) noexcept
 {
   if (parent_context && !parent_context->HasRemoteParent())
   {

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -60,7 +60,7 @@ trace_api::SpanId GenerateRandomSpanId()
 Span::Span(std::shared_ptr<Tracer> &&tracer,
            std::shared_ptr<SpanProcessor> processor,
            nostd::string_view name,
-           const trace_api::KeyValueIterable &attributes,
+           const opentelemetry::common::KeyValueIterable &attributes,
            const trace_api::StartSpanOptions &options,
            const trace_api::SpanContext &parent_span_context) noexcept
     : tracer_{std::move(tracer)},
@@ -138,7 +138,7 @@ void Span::AddEvent(nostd::string_view name, core::SystemTimestamp timestamp) no
 
 void Span::AddEvent(nostd::string_view name,
                     core::SystemTimestamp timestamp,
-                    const trace_api::KeyValueIterable &attributes) noexcept
+                    const opentelemetry::common::KeyValueIterable &attributes) noexcept
 {
   std::lock_guard<std::mutex> lock_guard{mu_};
   if (recordable_ == nullptr)

--- a/sdk/src/trace/span.h
+++ b/sdk/src/trace/span.h
@@ -18,7 +18,7 @@ public:
   explicit Span(std::shared_ptr<Tracer> &&tracer,
                 std::shared_ptr<SpanProcessor> processor,
                 nostd::string_view name,
-                const trace_api::KeyValueIterable &attributes,
+                const opentelemetry::common::KeyValueIterable &attributes,
                 const trace_api::StartSpanOptions &options,
                 const trace_api::SpanContext &parent_span_context) noexcept;
 
@@ -33,7 +33,7 @@ public:
 
   void AddEvent(nostd::string_view name,
                 core::SystemTimestamp timestamp,
-                const trace_api::KeyValueIterable &attributes) noexcept override;
+                const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
 
   void SetStatus(trace_api::CanonicalCode code, nostd::string_view description) noexcept override;
 

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -53,7 +53,7 @@ trace_api::SpanContext GetCurrentSpanContext(const trace_api::SpanContext &expli
 
 nostd::shared_ptr<trace_api::Span> Tracer::StartSpan(
     nostd::string_view name,
-    const trace_api::KeyValueIterable &attributes,
+    const opentelemetry::common::KeyValueIterable &attributes,
     const trace_api::StartSpanOptions &options) noexcept
 {
   trace_api::SpanContext parent = GetCurrentSpanContext(options.parent);

--- a/sdk/test/metrics/controller_test.cc
+++ b/sdk/test/metrics/controller_test.cc
@@ -34,7 +34,7 @@ TEST(Controller, Constructor)
 
   auto instr                                = meter->NewIntCounter("test", "none", "none", true);
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha.start();
 

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -69,7 +69,7 @@ TEST(Meter, CollectSyncInstruments)
   auto counter = m.NewShortCounter("Test-counter", "For testing", "Unitless", true);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
 
   counter->add(1, labelkv);
 
@@ -101,7 +101,7 @@ TEST(Meter, CollectDeletedSync)
   ASSERT_EQ(m.Collect().size(), 0);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
   {
     auto counter = m.NewShortCounter("Test-counter", "For testing", "Unitless", true);
     counter->add(1, labelkv);
@@ -118,7 +118,7 @@ TEST(Meter, CollectDeletedSync)
 void Callback(opentelemetry::metrics::ObserverResult<short> result)
 {
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   result.observe(1, labelkv);
 }
 
@@ -134,7 +134,7 @@ TEST(Meter, CollectAsyncInstruments)
       m.NewShortSumObserver("Test-counter", "For testing", "Unitless", true, &ShortCallback);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
 
   sumobs->observe(1, labelkv);
 
@@ -166,7 +166,7 @@ TEST(Meter, CollectDeletedAsync)
   ASSERT_EQ(m.Collect().size(), 0);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
   {
     auto sumobs = m.NewShortSumObserver("Test-counter", "For testing", "Unitless", true, &Callback);
     sumobs->observe(1, labelkv);
@@ -191,7 +191,7 @@ TEST(Meter, RecordBatch)
   auto dcounter = m.NewDoubleCounter("Test-dcounter", "For testing", "Unitless", true);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
 
   metrics_api::SynchronousInstrument<short> *sinstr_arr[] = {scounter.get()};
   short svalues_arr[]                                     = {1};
@@ -246,7 +246,7 @@ TEST(Meter, DisableCollectSync)
 {
   Meter m("Test");
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
   auto c       = m.NewShortCounter("c", "", "", false);
   c->add(1, labelkv);
   ASSERT_EQ(m.Collect().size(), 0);
@@ -256,7 +256,7 @@ TEST(Meter, DisableCollectAsync)
 {
   Meter m("Test");
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
   auto c       = m.NewShortValueObserver("c", "", "", false, &ShortCallback);
   c->observe(1, labelkv);
   ASSERT_EQ(m.Collect().size(), 0);

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -20,7 +20,7 @@ namespace metrics
 void ObserverConstructorCallback(metrics_api::ObserverResult<int> result)
 {
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   result.observe(1, labelkv);
 }
 
@@ -31,7 +31,7 @@ TEST(ApiSdkConversion, async)
           new ValueObserver<int>("ankit", "none", "unitles", true, &ObserverConstructorCallback));
 
   std::map<std::string, std::string> labels = {{"key587", "value264"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   alpha->observe(123456, labelkv);
   EXPECT_EQ(dynamic_cast<AsynchronousInstrument<int> *>(alpha.get())->GetRecords()[0].GetLabels(),
@@ -50,7 +50,7 @@ TEST(IntValueObserver, InstrumentFunctions)
   ValueObserver<int> alpha("enabled", "no description", "unitless", true,
                            &ObserverConstructorCallback);
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   EXPECT_EQ(alpha.GetName(), "enabled");
   EXPECT_EQ(alpha.GetDescription(), "no description");
@@ -64,7 +64,7 @@ TEST(IntValueObserver, InstrumentFunctions)
 
 void ObserverCallback(std::shared_ptr<ValueObserver<int>> in,
                       int freq,
-                      const trace::KeyValueIterable &labels)
+                      const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -74,7 +74,7 @@ void ObserverCallback(std::shared_ptr<ValueObserver<int>> in,
 
 void NegObserverCallback(std::shared_ptr<ValueObserver<int>> in,
                          int freq,
-                         const trace::KeyValueIterable &labels)
+                         const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -89,8 +89,8 @@ TEST(IntValueObserver, StressObserve)
 
   std::map<std::string, std::string> labels  = {{"key", "value"}};
   std::map<std::string, std::string> labels1 = {{"key1", "value1"}};
-  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
-  auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
+  auto labelkv  = common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv1 = common::KeyValueIterableView<decltype(labels1)>{labels1};
 
   std::thread first(ObserverCallback, alpha, 25,
                     labelkv);  // spawn new threads that call the callback
@@ -116,7 +116,7 @@ TEST(IntValueObserver, StressObserve)
 
 void SumObserverCallback(std::shared_ptr<SumObserver<int>> in,
                          int freq,
-                         const trace::KeyValueIterable &labels)
+                         const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -131,8 +131,8 @@ TEST(IntSumObserver, StressObserve)
 
   std::map<std::string, std::string> labels  = {{"key", "value"}};
   std::map<std::string, std::string> labels1 = {{"key1", "value1"}};
-  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
-  auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
+  auto labelkv  = common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv1 = common::KeyValueIterableView<decltype(labels1)>{labels1};
 
   std::thread first(SumObserverCallback, alpha, 100000, labelkv);
   std::thread second(SumObserverCallback, alpha, 100000, labelkv);
@@ -148,7 +148,7 @@ TEST(IntSumObserver, StressObserve)
 
 void UpDownSumObserverCallback(std::shared_ptr<UpDownSumObserver<int>> in,
                                int freq,
-                               const trace::KeyValueIterable &labels)
+                               const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -158,7 +158,7 @@ void UpDownSumObserverCallback(std::shared_ptr<UpDownSumObserver<int>> in,
 
 void NegUpDownSumObserverCallback(std::shared_ptr<UpDownSumObserver<int>> in,
                                   int freq,
-                                  const trace::KeyValueIterable &labels)
+                                  const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -173,8 +173,8 @@ TEST(IntUpDownObserver, StressAdd)
 
   std::map<std::string, std::string> labels  = {{"key", "value"}};
   std::map<std::string, std::string> labels1 = {{"key1", "value1"}};
-  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
-  auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
+  auto labelkv  = common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv1 = common::KeyValueIterableView<decltype(labels1)>{labels1};
 
   std::thread first(UpDownSumObserverCallback, alpha, 12340,
                     labelkv);  // spawn new threads that call the callback
@@ -216,10 +216,10 @@ TEST(Counter, Binding)
   std::map<std::string, std::string> labels2 = {{"key2", "value2"}, {"key3", "value3"}};
   std::map<std::string, std::string> labels3 = {{"key3", "value3"}, {"key2", "value2"}};
 
-  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
-  auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
-  auto labelkv2 = trace::KeyValueIterableView<decltype(labels2)>{labels2};
-  auto labelkv3 = trace::KeyValueIterableView<decltype(labels3)>{labels3};
+  auto labelkv  = common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv1 = common::KeyValueIterableView<decltype(labels1)>{labels1};
+  auto labelkv2 = common::KeyValueIterableView<decltype(labels2)>{labels2};
+  auto labelkv3 = common::KeyValueIterableView<decltype(labels3)>{labels3};
 
   auto beta    = alpha.bindCounter(labelkv);
   auto gamma   = alpha.bindCounter(labelkv1);
@@ -246,7 +246,7 @@ TEST(Counter, getAggsandnewupdate)
 
   std::map<std::string, std::string> labels = {{"key3", "value3"}, {"key2", "value2"}};
 
-  auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   auto beta    = alpha.bindCounter(labelkv);
   beta->add(1);
   beta->unbind();
@@ -263,7 +263,7 @@ TEST(Counter, getAggsandnewupdate)
 
 void CounterCallback(std::shared_ptr<Counter<int>> in,
                      int freq,
-                     const trace::KeyValueIterable &labels)
+                     const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -278,8 +278,8 @@ TEST(Counter, StressAdd)
   std::map<std::string, std::string> labels  = {{"key", "value"}};
   std::map<std::string, std::string> labels1 = {{"key1", "value1"}};
 
-  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
-  auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
+  auto labelkv  = common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv1 = common::KeyValueIterableView<decltype(labels1)>{labels1};
 
   std::thread first(CounterCallback, alpha, 1000, labelkv);
   std::thread second(CounterCallback, alpha, 1000, labelkv);
@@ -301,7 +301,7 @@ TEST(Counter, StressAdd)
 
 void UpDownCounterCallback(std::shared_ptr<UpDownCounter<int>> in,
                            int freq,
-                           const trace::KeyValueIterable &labels)
+                           const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -311,7 +311,7 @@ void UpDownCounterCallback(std::shared_ptr<UpDownCounter<int>> in,
 
 void NegUpDownCounterCallback(std::shared_ptr<UpDownCounter<int>> in,
                               int freq,
-                              const trace::KeyValueIterable &labels)
+                              const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -326,8 +326,8 @@ TEST(IntUpDownCounter, StressAdd)
 
   std::map<std::string, std::string> labels  = {{"key", "value"}};
   std::map<std::string, std::string> labels1 = {{"key1", "value1"}};
-  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
-  auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
+  auto labelkv  = common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv1 = common::KeyValueIterableView<decltype(labels1)>{labels1};
 
   std::thread first(UpDownCounterCallback, alpha, 12340,
                     labelkv);  // spawn new threads that call the callback
@@ -354,7 +354,7 @@ TEST(IntUpDownCounter, StressAdd)
 
 void RecorderCallback(std::shared_ptr<ValueRecorder<int>> in,
                       int freq,
-                      const trace::KeyValueIterable &labels)
+                      const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -364,7 +364,7 @@ void RecorderCallback(std::shared_ptr<ValueRecorder<int>> in,
 
 void NegRecorderCallback(std::shared_ptr<ValueRecorder<int>> in,
                          int freq,
-                         const trace::KeyValueIterable &labels)
+                         const common::KeyValueIterable &labels)
 {
   for (int i = 0; i < freq; i++)
   {
@@ -379,8 +379,8 @@ TEST(IntValueRecorder, StressRecord)
 
   std::map<std::string, std::string> labels  = {{"key", "value"}};
   std::map<std::string, std::string> labels1 = {{"key1", "value1"}};
-  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
-  auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
+  auto labelkv  = common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv1 = common::KeyValueIterableView<decltype(labels1)>{labels1};
 
   std::thread first(RecorderCallback, alpha, 25,
                     labelkv);  // spawn new threads that call the callback
@@ -445,7 +445,7 @@ TEST(Instruments, NoUpdateNoRecord)
 
   std::map<std::string, std::string> labels = {{"key", "value"}};
 
-  auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   EXPECT_EQ(alpha.GetRecords().size(), 0);
   alpha.add(1, labelkv);

--- a/sdk/test/trace/always_off_sampler_test.cc
+++ b/sdk/test/trace/always_off_sampler_test.cc
@@ -14,7 +14,7 @@ TEST(AlwaysOffSampler, ShouldSample)
 
   using M = std::map<std::string, int>;
   M m1    = {{}};
-  opentelemetry::trace::KeyValueIterableView<M> view{m1};
+  opentelemetry::common::KeyValueIterableView<M> view{m1};
 
   auto sampling_result = sampler.ShouldSample(nullptr, trace_id, "", span_kind, view);
 

--- a/sdk/test/trace/always_on_sampler_test.cc
+++ b/sdk/test/trace/always_on_sampler_test.cc
@@ -21,7 +21,7 @@ TEST(AlwaysOnSampler, ShouldSample)
   // Test with invalid (empty) trace id and empty parent context
   auto sampling_result = sampler.ShouldSample(
       nullptr, trace_id_invalid, "invalid trace id test", trace_api::SpanKind::kServer,
-      trace_api::KeyValueIterableView<std::map<std::string, int>>(key_value_container));
+      opentelemetry::common::KeyValueIterableView<std::map<std::string, int>>(key_value_container));
 
   ASSERT_EQ(Decision::RECORD_AND_SAMPLE, sampling_result.decision);
   ASSERT_EQ(nullptr, sampling_result.attributes);
@@ -29,7 +29,7 @@ TEST(AlwaysOnSampler, ShouldSample)
   // Test with a valid trace id and empty parent context
   sampling_result = sampler.ShouldSample(
       nullptr, trace_id_valid, "valid trace id test", trace_api::SpanKind::kServer,
-      trace_api::KeyValueIterableView<std::map<std::string, int>>(key_value_container));
+      opentelemetry::common::KeyValueIterableView<std::map<std::string, int>>(key_value_container));
 
   ASSERT_EQ(Decision::RECORD_AND_SAMPLE, sampling_result.decision);
   ASSERT_EQ(nullptr, sampling_result.attributes);

--- a/sdk/test/trace/attribute_utils_test.cc
+++ b/sdk/test/trace/attribute_utils_test.cc
@@ -16,7 +16,7 @@ TEST(AttributeMapTest, AttributesConstruction)
   std::map<std::string, int> attributes = {
       {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
 
-  opentelemetry::trace::KeyValueIterableView<std::map<std::string, int>> iterable(attributes);
+  opentelemetry::common::KeyValueIterableView<std::map<std::string, int>> iterable(attributes);
   opentelemetry::sdk::trace::AttributeMap map(iterable);
 
   for (int i = 0; i < kNumAttributes; i++)

--- a/sdk/test/trace/parent_or_else_sampler_test.cc
+++ b/sdk/test/trace/parent_or_else_sampler_test.cc
@@ -20,7 +20,7 @@ TEST(ParentOrElseSampler, ShouldSample)
   opentelemetry::trace::SpanKind span_kind = opentelemetry::trace::SpanKind::kInternal;
   using M                                  = std::map<std::string, int>;
   M m1                                     = {{}};
-  opentelemetry::trace::KeyValueIterableView<M> view{m1};
+  opentelemetry::common::KeyValueIterableView<M> view{m1};
   SpanContext parent_context_sampled(true, false);
   SpanContext parent_context_nonsampled(false, false);
 

--- a/sdk/test/trace/probability_sampler_test.cc
+++ b/sdk/test/trace/probability_sampler_test.cc
@@ -32,7 +32,7 @@ int RunShouldSampleCountDecision(SpanContext &context, ProbabilitySampler &sampl
 
   using M = std::map<std::string, int>;
   M m1    = {{}};
-  opentelemetry::trace::KeyValueIterableView<M> view{m1};
+  opentelemetry::common::KeyValueIterableView<M> view{m1};
 
   for (int i = 0; i < iterations; ++i)
   {
@@ -60,7 +60,7 @@ TEST(ProbabilitySampler, ShouldSampleWithoutContext)
 
   using M = std::map<std::string, int>;
   M m1    = {{}};
-  opentelemetry::trace::KeyValueIterableView<M> view{m1};
+  opentelemetry::common::KeyValueIterableView<M> view{m1};
 
   ProbabilitySampler s1(0.01);
 
@@ -110,7 +110,7 @@ TEST(ProbabilitySampler, ShouldSampleWithContext)
 
   using M = std::map<std::string, int>;
   M m1    = {{}};
-  opentelemetry::trace::KeyValueIterableView<M> view{m1};
+  opentelemetry::common::KeyValueIterableView<M> view{m1};
 
   ProbabilitySampler s1(0.01);
 

--- a/sdk/test/trace/sampler_benchmark.cc
+++ b/sdk/test/trace/sampler_benchmark.cc
@@ -63,7 +63,7 @@ void BenchmarkShouldSampler(Sampler &sampler, benchmark::State &state)
 
   using M = std::map<std::string, int>;
   M m1    = {{}};
-  opentelemetry::trace::KeyValueIterableView<M> view{m1};
+  opentelemetry::common::KeyValueIterableView<M> view{m1};
 
   while (state.KeepRunning())
   {

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -65,7 +65,7 @@ TEST(SpanData, EventAttributes)
 
   data.AddEvent(
       "Test Event", std::chrono::system_clock::now(),
-      opentelemetry::trace::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
+      opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
 
   for (int i = 0; i < kNumAttributes; i++)
   {
@@ -86,7 +86,7 @@ TEST(SpanData, Links)
 
   data.AddLink(
       opentelemetry::trace::SpanContext(false, false),
-      opentelemetry::trace::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
+      opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
 
   for (int i = 0; i < kNumAttributes; i++)
   {

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -23,11 +23,12 @@ using opentelemetry::trace::SpanContext;
 class MockSampler final : public Sampler
 {
 public:
-  SamplingResult ShouldSample(const SpanContext * /*parent_context*/,
-                              trace_api::TraceId /*trace_id*/,
-                              nostd::string_view /*name*/,
-                              trace_api::SpanKind /*span_kind*/,
-                              const trace_api::KeyValueIterable & /*attributes*/) noexcept override
+  SamplingResult ShouldSample(
+      const SpanContext * /*parent_context*/,
+      trace_api::TraceId /*trace_id*/,
+      nostd::string_view /*name*/,
+      trace_api::SpanKind /*span_kind*/,
+      const opentelemetry::common::KeyValueIterable & /*attributes*/) noexcept override
   {
     // Return two pairs of attributes. These attributes should be added to the
     // span attributes


### PR DESCRIPTION
A simple PR based on [this comment](https://github.com/open-telemetry/opentelemetry-cpp/issues/356#issuecomment-705937393) from @maxgolov.

Since `KeyValueIterable` is used by metrics, traces, and logs alike, it would be better if it belonged to the “common” namespace as it is no longer exclusive to being used for “trace”.  

In this PR, `KeyValueIterable` and the derived class `KeyValueIterableView` are refactored from namespace `trace::*` to `common::*` and their corresponding  `*.h` files are moved from `api/.../trace` to `api/.../common`. 

The change continues to pass the [key_value_iterable_view_test.cc](https://github.com/open-telemetry/opentelemetry-cpp/blob/master/api/test/trace/key_value_iterable_view_test.cc), which runs unit tests for the abstract KeyValueIterable class and KeyValueIterableView inherited class, and does not break the build tests. 

cc @alolita @MarkSeufert 
