### PR TITLE
Add simple log processor implementation and tests, and log exporter interface

### DIFF
--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "opentelemetry/logs/log_record.h"
+#include "opentelemetry/sdk/logs/processor.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+/**
+ * ExportResult is returned as result of exporting a batch of Log Records.
+ */
+enum class ExportResult
+{
+  // The batch was exported successfully
+  kSuccess = 0,
+  // The batch was exported unsuccessfully and was dropped
+  kFailure
+};
+
+/**
+ * LogExporter defines the interface that log exporters must implement.
+ */
+class LogExporter
+{
+public:
+  virtual ~LogExporter() = default;
+
+  /**
+   * Exporters that implement this should typically format each LogRecord into the format
+   * required by the exporter destination (e.g. JSON), then send the LogRecord to the exporter.
+   * The exporter may retry logs a maximum of 3 times before dropping and returning kFailure.
+   * If this exporter is already shut down, should return kFailure.
+   * @param records: a vector of unique pointers to log records
+   * @returns an ExportResult code (whether export was success or failure)
+   *
+   * TODO: This method should not block indefinitely. Should abort within timeout.
+   */
+  virtual ExportResult Export(
+      const std::vector<std::unique_ptr<opentelemetry::logs::LogRecord>> &records) noexcept = 0;
+
+  /**
+   * Marks the exporter as ShutDown and cleans up any resources as required.
+   * Shutdown should be called only once for each Exporter instance.
+   * @param timeout this method should not block indefinitely; should abort within timeout.
+   * @return a ShutDownResult code (if it succeeded, failed or timed out)
+   */
+  virtual ShutdownResult Shutdown(
+      std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept = 0;
+};
+}  // namespace logs
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/logs/processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/processor.h
@@ -25,21 +25,44 @@ namespace sdk
 {
 namespace logs
 {
+enum class ShutdownResult
+{
+  kSuccess = 0,
+  kFailure = 1,
+  kTimeout = 2
+};
 /**
- * This Log Processor is responsible for conversion of logs to exportable
- * representation and passing them to exporters.
+ * This Log Processor is responsible for the batching of log records
+ * and passing them to exporters.
  */
 class LogProcessor
 {
 public:
   virtual ~LogProcessor() = default;
 
+  /**
+   * OnReceive is responsible for batching every log record that is created by the SDK
+   * @param record a log record that has all the user data and injected data
+   */
   virtual void OnReceive(std::unique_ptr<opentelemetry::logs::LogRecord> &&record) noexcept = 0;
 
-  virtual void ForceFlush(
+  /**
+   * Exports all log records that have not yet been exported to the configured Exporter.
+   * @param timeout that the forceflush is required to finish within.
+   * A default timeout of 0 mean no timeout is applied.
+   * @return a result code indicating whether it succeeded, failed or timed out
+   */
+  virtual ShutdownResult ForceFlush(
       std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept = 0;
 
-  virtual void Shutdown(
+  /**
+   * Shuts down the processor and does any cleanup required.
+   * ShutDown should only be called once for each processor.
+   * @param timeout that the shutdown should finish within.
+   * A default timeout of 0 means no timeout is applied.
+   * @return a ShutDown result (if it succeeded, failed or timed out)
+   */
+  virtual ShutdownResult Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept = 0;
 };
 }  // namespace logs

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <mutex>
+
+#include "opentelemetry/common/spin_lock_mutex.h"
+#include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/sdk/logs/processor.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+/**
+ * The simple log processor passes all log records
+ * in a batch of 1 to the configured
+ * LogExporter.
+ *
+ * All calls to the configured LogExporter are synchronized using a
+ * spin-lock on an atomic_flag.
+ */
+class SimpleLogProcessor : public LogProcessor
+{
+
+public:
+  explicit SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter);
+  virtual ~SimpleLogProcessor() = default;
+
+  void OnReceive(std::unique_ptr<opentelemetry::logs::LogRecord> &&record) noexcept override;
+
+  ShutdownResult ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept override;
+
+  ShutdownResult Shutdown(
+      std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept override;
+
+private:
+  // The configured exporter
+  std::unique_ptr<LogExporter> exporter_;
+  // The lock used to ensure the exporter is not called concurrently
+  opentelemetry::common::SpinLockMutex lock_;
+  // The atomic boolean flag to ensure the ShutDown() function is only called once
+  std::atomic_flag shutdown_latch_{ATOMIC_FLAG_INIT};
+};
+}  // namespace logs
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/logs/CMakeLists.txt
+++ b/sdk/src/logs/CMakeLists.txt
@@ -1,3 +1,4 @@
-add_library(opentelemetry_logs logger_provider.cc logger.cc)
+add_library(opentelemetry_logs logger_provider.cc logger.cc
+                               simple_log_processor.cc)
 
 target_link_libraries(opentelemetry_logs opentelemetry_common)

--- a/sdk/src/logs/simple_log_processor.cc
+++ b/sdk/src/logs/simple_log_processor.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "opentelemetry/sdk/logs/simple_log_processor.h"
+
+#include <chrono>
+#include <vector>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+/**
+ * Initialize a simple log processor.
+ * @param exporter the configured exporter where log records are sent
+ */
+SimpleLogProcessor::SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter)
+    : exporter_(std::move(exporter))
+{}
+
+/**
+ * Batches the log record it receives in a batch of 1 and immediately sends it
+ * to the configured exporter
+ */
+void SimpleLogProcessor::OnReceive(
+    std::unique_ptr<opentelemetry::logs::LogRecord> &&record) noexcept
+{
+  std::vector<std::unique_ptr<opentelemetry::logs::LogRecord>> batch;
+  batch.emplace_back(std::move(record));
+
+  // Get lock to ensure Export() is never called concurrently
+  std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+
+  if (exporter_->Export(batch) == ExportResult::kFailure)
+  {
+    /* TODO: alert user of the failed or timedout export result */
+  }
+}
+
+/**
+ *  The simple processor does not have any log records to flush so this method is not used
+ */
+ShutdownResult SimpleLogProcessor::ForceFlush(std::chrono::microseconds timeout) noexcept
+{
+  return ShutdownResult::kSuccess;
+}
+
+/**
+ * TODO: This method should not block indefinitely. Should abort within timeout.
+ */
+ShutdownResult SimpleLogProcessor::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  if (timeout < std::chrono::microseconds(0))
+  {
+    // TODO: alert caller of invalid timeout?
+    return ShutdownResult::kFailure;
+  }
+
+  // Should only shutdown exporter ONCE.
+  if (!shutdown_latch_.test_and_set(std::memory_order_acquire))
+  {
+    return exporter_->Shutdown(timeout);
+  }
+
+  return ShutdownResult::kFailure;
+}
+}  // namespace logs
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/test/logs/BUILD
+++ b/sdk/test/logs/BUILD
@@ -20,3 +20,14 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "simple_log_processor_test",
+    srcs = [
+        "simple_log_processor_test.cc",
+    ],
+    deps = [
+        "//sdk/src/logs",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/sdk/test/logs/CMakeLists.txt
+++ b/sdk/test/logs/CMakeLists.txt
@@ -1,4 +1,5 @@
-foreach(testname logger_provider_sdk_test logger_sdk_test)
+foreach(testname logger_provider_sdk_test logger_sdk_test
+                 simple_log_processor_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_logs)

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -70,8 +70,15 @@ TEST(LoggerProviderSDK, LoggerProviderLoggerArguments)
 class DummyProcessor : public LogProcessor
 {
   void OnReceive(std::unique_ptr<opentelemetry::logs::LogRecord> &&record) noexcept {}
-  void ForceFlush(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept {}
-  void Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept {}
+  ShutdownResult ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept
+  {
+    return ShutdownResult::kSuccess;
+  }
+  ShutdownResult Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept
+  {
+    return ShutdownResult::kSuccess;
+  }
 };
 
 TEST(LoggerProviderSDK, GetAndSetProcessor)

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -38,8 +38,15 @@ TEST(LoggerSDK, LogToNullProcessor)
 class DummyProcessor : public LogProcessor
 {
   void OnReceive(std::unique_ptr<opentelemetry::logs::LogRecord> &&record) noexcept {}
-  void ForceFlush(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept {}
-  void Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept {}
+  ShutdownResult ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept
+  {
+    return ShutdownResult::kSuccess;
+  }
+  ShutdownResult Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept
+  {
+    return ShutdownResult::kSuccess;
+  }
 };
 
 TEST(LoggerSDK, LogToAProcessor)

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -1,0 +1,161 @@
+#include "opentelemetry/sdk/logs/simple_log_processor.h"
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+using namespace opentelemetry::sdk::logs;
+using opentelemetry::logs::LogRecord;
+
+/*
+ * A test exporter that can return a vector of all the records it has received,
+ * and keep track of the number of times its Shutdown() function was called.
+ */
+class TestExporter final : public LogExporter
+{
+public:
+  TestExporter(int *shutdown_counter,
+               std::shared_ptr<std::vector<std::string>> logs_received,
+               int *batch_size_received)
+      : shutdown_counter_(shutdown_counter),
+        logs_received_(logs_received),
+        batch_size_received(batch_size_received)
+  {}
+
+  // Stores the names of the log records this exporter receives to an internal list
+  ExportResult Export(const std::vector<std::unique_ptr<LogRecord>> &records) noexcept override
+  {
+    *batch_size_received = records.size();
+    for (auto &record : records)
+    {
+      logs_received_->push_back(record->name.data());
+    }
+    return ExportResult::kSuccess;
+  }
+
+  // Increment the shutdown counter everytime this method is called
+  ShutdownResult Shutdown(std::chrono::microseconds timeout) noexcept override
+  {
+    *shutdown_counter_ += 1;
+    return ShutdownResult::kSuccess;
+  }
+
+private:
+  int *shutdown_counter_;
+  std::shared_ptr<std::vector<std::string>> logs_received_;
+  int *batch_size_received;
+};
+
+// Tests whether the simple processor successfully creates a batch of size 1
+// and whether the contents of the record is sent to the exporter correctly
+TEST(SimpleLogProcessorTest, SendReceivedLogsToExporter)
+{
+  // Create a simple processor with a TestExporter attached
+  std::shared_ptr<std::vector<std::string>> logs_received(new std::vector<std::string>);
+  int batch_size_received = 0;
+
+  std::unique_ptr<TestExporter> exporter(
+      new TestExporter(nullptr, logs_received, &batch_size_received));
+
+  SimpleLogProcessor processor(std::move(exporter));
+
+  // Send some log records to the processor (which should then send to the TestExporter)
+  const int num_logs = 5;
+  for (int i = 0; i < num_logs; i++)
+  {
+    auto record = std::unique_ptr<LogRecord>(new LogRecord());
+    std::string s("Log name");
+    s += std::to_string(i);
+    record->name = s;
+
+    processor.OnReceive(std::move(record));
+
+    // Verify that the batch of 1 log record sent by processor matches what exporter received
+    EXPECT_EQ(1, batch_size_received);
+  }
+
+  // Test whether the processor's log sent matches the log record received by the exporter
+  EXPECT_EQ(logs_received->size(), num_logs);
+  for (int i = 0; i < num_logs; i++)
+  {
+    std::string s("Log name");
+    s += std::to_string(i);
+    EXPECT_EQ(s, logs_received->at(i));
+  }
+}
+
+// Tests behavior when calling the processor's ShutDown() multiple times
+TEST(SimpleLogProcessorTest, ShutdownCalledOnce)
+{
+  // Create a TestExporter
+  int num_shutdowns = 0;
+
+  std::unique_ptr<TestExporter> exporter(new TestExporter(&num_shutdowns, nullptr, nullptr));
+
+  // Create a processor with the previous test exporter
+  SimpleLogProcessor processor(std::move(exporter));
+
+  // The first time processor shutdown is called
+  EXPECT_EQ(0, num_shutdowns);
+  EXPECT_EQ(ShutdownResult::kSuccess, processor.Shutdown());
+  EXPECT_EQ(1, num_shutdowns);
+
+  // The second time processor shutdown is called
+  EXPECT_EQ(ShutdownResult::kFailure, processor.Shutdown());
+  // Processor::ShutDown(), even if called more than once, should only shutdown exporter once
+  EXPECT_EQ(1, num_shutdowns);
+}
+
+class SlowShutDownExporter final : public LogExporter
+{
+public:
+  SlowShutDownExporter() {}
+
+  ExportResult Export(const std::vector<std::unique_ptr<LogRecord>> &records) noexcept override
+  {
+    return ExportResult::kSuccess;
+  }
+
+  ShutdownResult Shutdown(std::chrono::microseconds timeout) noexcept override
+  {
+    return ShutdownResult::kTimeout;
+  }
+};
+
+// Tests whether processor shutdown times out when exporter shutdown times out
+TEST(SimpleLogProcessorTest, ShutDownTimeout)
+{
+  std::unique_ptr<SlowShutDownExporter> exporter(new SlowShutDownExporter());
+  SimpleLogProcessor processor(std::move(exporter));
+  EXPECT_EQ(ShutdownResult::kTimeout, processor.Shutdown(std::chrono::microseconds(1)));
+}
+
+// A test exporter that always returns failure when shut down
+class FailShutDownExporter final : public LogExporter
+{
+public:
+  FailShutDownExporter() {}
+
+  ExportResult Export(const std::vector<std::unique_ptr<LogRecord>> &records) noexcept override
+  {
+    return ExportResult::kSuccess;
+  }
+
+  ShutdownResult Shutdown(std::chrono::microseconds timeout) noexcept override
+  {
+    return ShutdownResult::kFailure;
+  }
+};
+
+// Tests for when when processor should fail to shutdown
+TEST(SimpleLogProcessorTest, ShutDownFail)
+{
+  std::unique_ptr<FailShutDownExporter> exporter(new FailShutDownExporter());
+  SimpleLogProcessor processor(std::move(exporter));
+
+  // Expect failure result when exporter fails to shutdown
+  EXPECT_EQ(ShutdownResult::kFailure, processor.Shutdown());
+
+  // Expect failure result when processor given a negative timeout allowed to shutdown
+  EXPECT_EQ(ShutdownResult::kFailure, processor.Shutdown(std::chrono::microseconds(-1)));
+}


### PR DESCRIPTION
This PR adds the simple log processor implementation and unit tests, as well as a log exporter interface for # 337. The simple processor sends Log Records from the SDK directly to an exporter in a batch of one, and its design currently follows the [trace specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-processor).  The log exporter interface is used for the simple processor unit tests.  

Currently, the processor's Shutdown() function does not forcibly abort if the processor shutdown exceeds the max timeout. This functionality should be added in the future, and similarly for [traces' simple span processor](https://github.com/open-telemetry/opentelemetry-cpp/blob/master/sdk/include/opentelemetry/sdk/trace/simple_processor.h#L57) as well. 

cc @alolita @MarkSeufert 