### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 
 # Bazel files
 /bazel-*
+
+# Mac
+*.DS_Store


### PR DESCRIPTION
Closes issue [#384](https://github.com/open-telemetry/opentelemetry-cpp/issues/384), where Mac specific `.DS_Store` files were not excluded automatically. 

cc - @alolita 