### PR TITLE
Add trace context injection and Logger limit to Logging SDK

### DIFF
--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -55,7 +55,7 @@ public:
    * @returns an ExportResult code (whether export was success or failure)
    */
   virtual ExportResult Export(
-      const nostd::span<std::unique_ptr<opentelemetry::logs::LogRecord>> &records) noexcept = 0;
+      const nostd::span<std::shared_ptr<opentelemetry::logs::LogRecord>> &records) noexcept = 0;
 
   /**
    * Marks the exporter as ShutDown and cleans up any resources as required.

--- a/sdk/include/opentelemetry/sdk/logs/logger_provider.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger_provider.h
@@ -29,8 +29,8 @@
 #include "opentelemetry/sdk/logs/processor.h"
 
 // Define the maximum number of loggers that are allowed to be registered to the loggerprovider.
-// TODO: Add link to logging spec once this is added to it
-#define MAX_LOGGER_COUNT 100
+// References spec issue https://github.com/open-telemetry/opentelemetry-specification/issues/1259
+#define OTEL_MAX_LOGGER_COUNT 1000
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -95,6 +95,9 @@ private:
 
   // A mutex that ensures only one thread is using the map of loggers
   std::mutex mu_;
+
+  // A noop logger that is returned by GetLogger() when OTEL_MAX_LOGGER_COUNT reached
+  opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> noop_logger_;
 };
 }  // namespace logs
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/logs/processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/processor.h
@@ -38,7 +38,7 @@ public:
    * OnReceive is called by the SDK once a log record has been successfully created.
    * @param record the log record
    */
-  virtual void OnReceive(std::unique_ptr<opentelemetry::logs::LogRecord> &&record) noexcept = 0;
+  virtual void OnReceive(std::shared_ptr<opentelemetry::logs::LogRecord> record) noexcept = 0;
 
   /**
    * Exports all log records that have not yet been exported to the configured Exporter.

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
@@ -43,7 +43,7 @@ public:
   explicit SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter);
   virtual ~SimpleLogProcessor() = default;
 
-  void OnReceive(std::unique_ptr<opentelemetry::logs::LogRecord> &&record) noexcept override;
+  void OnReceive(std::shared_ptr<opentelemetry::logs::LogRecord> record) noexcept override;
 
   bool ForceFlush(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;

--- a/sdk/src/logs/BUILD
+++ b/sdk/src/logs/BUILD
@@ -22,5 +22,6 @@ cc_library(
     deps = [
         "//api",
         "//sdk:headers",
+        "//sdk/src/trace",
     ],
 )

--- a/sdk/src/logs/CMakeLists.txt
+++ b/sdk/src/logs/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(opentelemetry_logs logger_provider.cc logger.cc
                                simple_log_processor.cc)
 
-target_link_libraries(opentelemetry_logs opentelemetry_common)
+target_link_libraries(opentelemetry_logs opentelemetry_common
+                      opentelemetry_trace)

--- a/sdk/src/logs/simple_log_processor.cc
+++ b/sdk/src/logs/simple_log_processor.cc
@@ -36,14 +36,15 @@ SimpleLogProcessor::SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter)
  * Batches the log record it receives in a batch of 1 and immediately sends it
  * to the configured exporter
  */
-void SimpleLogProcessor::OnReceive(
-    std::unique_ptr<opentelemetry::logs::LogRecord> &&record) noexcept
+void SimpleLogProcessor::OnReceive(std::shared_ptr<opentelemetry::logs::LogRecord> record) noexcept
 {
-  nostd::span<std::unique_ptr<opentelemetry::logs::LogRecord>> batch(&record, 1);
+  std::vector<std::shared_ptr<opentelemetry::logs::LogRecord>> batch;
+  batch.emplace_back(record);
   // Get lock to ensure Export() is never called concurrently
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
 
-  if (exporter_->Export(batch) != ExportResult::kSuccess)
+  if (exporter_->Export(opentelemetry::nostd::span<std::shared_ptr<opentelemetry::logs::LogRecord>>(
+          batch.data(), batch.size())) != ExportResult::kSuccess)
   {
     /* Alert user of the failed export */
   }

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -26,7 +26,7 @@ public:
 
   // Stores the names of the log records this exporter receives to an internal list
   ExportResult Export(
-      const opentelemetry::nostd::span<std::unique_ptr<LogRecord>> &records) noexcept override
+      const opentelemetry::nostd::span<std::shared_ptr<LogRecord>> &records) noexcept override
   {
     *batch_size_received = records.size();
     for (auto &record : records)
@@ -66,12 +66,12 @@ TEST(SimpleLogProcessorTest, SendReceivedLogsToExporter)
   const int num_logs = 5;
   for (int i = 0; i < num_logs; i++)
   {
-    auto record = std::unique_ptr<LogRecord>(new LogRecord());
+    auto record = std::shared_ptr<LogRecord>(new LogRecord());
     std::string s("Log name");
     s += std::to_string(i);
     record->name = s;
 
-    processor.OnReceive(std::move(record));
+    processor.OnReceive(record);
 
     // Verify that the batch of 1 log record sent by processor matches what exporter received
     EXPECT_EQ(1, batch_size_received);
@@ -116,7 +116,7 @@ public:
   FailShutDownExporter() {}
 
   ExportResult Export(
-      const opentelemetry::nostd::span<std::unique_ptr<LogRecord>> &records) noexcept override
+      const opentelemetry::nostd::span<std::shared_ptr<LogRecord>> &records) noexcept override
   {
     return ExportResult::kSuccess;
   }


### PR DESCRIPTION
This PR makes two additions to the [logging SDK](https://github.com/open-telemetry/opentelemetry-cpp/pull/386):
* The SDK’s Logger injects fields of the LogRecord if the user didn’t specify them. The fields that get injected are timestamp, severity, traceid, spanid, and traceflags
* Added a logger limit to the SDK LoggerProvider ([relevant spec issue](https://github.com/open-telemetry/opentelemetry-specification/issues/1259)), which returns a noop logger if the limit has been reached.
* Unit tests for the above functionality

The CI tests will fail until the recent [API PR](https://github.com/open-telemetry/opentelemetry-cpp/pull/422) gets merged, since it uses some of the changes made from it.

