### PR TITLE
Add example use of ostream log exporter

### DIFF
--- a/examples/logs_simple/BUILD
+++ b/examples/logs_simple/BUILD
@@ -1,0 +1,27 @@
+cc_library(
+    name = "foo_library",
+    srcs = [
+        "foo_library/foo_library.cc",
+    ],
+    hdrs = [
+        "foo_library/foo_library.h",
+    ],
+    deps = [
+        "//api",
+    ],
+)
+
+cc_binary(
+    name = "example_logs_simple",
+    srcs = [
+        "main.cc",
+    ],
+    deps = [
+        ":foo_library",
+        "//api",
+        "//exporters/ostream:ostream_log_exporter",
+        "//exporters/ostream:ostream_span_exporter",
+        "//sdk/src/logs",
+        "//sdk/src/trace",
+    ],
+)

--- a/examples/logs_simple/CMakeLists.txt
+++ b/examples/logs_simple/CMakeLists.txt
@@ -1,0 +1,9 @@
+include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
+
+add_library(foo_library foo_library/foo_library.cc)
+target_link_libraries(foo_library opentelemetry_exporter_ostream_span
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+
+add_executable(example_logs_simple main.cc)
+target_link_libraries(example_logs_simple ${CMAKE_THREAD_LIBS_INIT}
+                      foo_library opentelemetry_logs)

--- a/examples/logs_simple/README.md
+++ b/examples/logs_simple/README.md
@@ -1,0 +1,61 @@
+
+# Simple Logging and Tracing Example
+
+In this example, the application in `main.cc` initializes and registers a tracer
+provider and logger provider from the [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-cpp).
+The application then calls a `foo_library` which has been instrumented using
+the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-cpp/tree/master/api).
+Resulting telemetry is directed to stdout through the  OStream Span Exporter. and OStream Log Exporter.
+
+## Usage
+
+The steps to initializing a Logger and writing the first logging statement is described below.
+
+1. Initialize a LoggerProvider. We will use this to obtain Loggers in the future.
+
+```
+auto logger_provider = std::shared_ptr<sdk::logs::LoggerProvider>(new sdklogs::LoggerProvider());
+```
+
+2. Initialize an exporter. In this example, we will use the Ostream Log Exporter, configured to print to `stdout`.
+
+```
+auto exporter = std::unique_ptr<sdk::logs::LogExporter>(new opentelemetry::exporter::logs::OStreamLogExporter);
+```
+
+3. Initialize an log processor. Here we'll use a simple processor.
+
+```
+auto processor = std::shared_ptr<sdk::logs::LogProcessor>(new sdk::logs::SimpleLogProcessor(std::move(exporter)));
+```
+
+4. Convert the SDK Logger Provider instance created to an API Logger Provider.
+
+```
+auto api_logger_provider = nostd::shared_ptr<logs_api::LoggerProvider>(logger_provider);
+```
+
+5. Set the logger provider created as the global one.
+
+```
+auto provider = nostd::shared_ptr<logs_api::LoggerProvider>(api_logger_provider);
+Provider::SetLoggerProvider(provider);
+```
+
+6. Get a Logger
+
+```
+auto logger = provider->GetLogger("logger_name");
+```
+
+7. Write a Log
+
+```
+logger->Log("Hello, World!");
+```
+
+
+A runnable example can be found in [/examples/logs_simple](https://github.com/open-telemetry/opentelemetry-cpp/tree/master/examples/logs_simple) folder.
+
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on building and running the example.

--- a/examples/logs_simple/foo_library/foo_library.cc
+++ b/examples/logs_simple/foo_library/foo_library.cc
@@ -1,6 +1,5 @@
 #include "opentelemetry/logs/provider.h"
 
-// Logs
 namespace logs  = opentelemetry::logs;
 namespace nostd = opentelemetry::nostd;
 using opentelemetry::logs::Severity;

--- a/examples/logs_simple/foo_library/foo_library.cc
+++ b/examples/logs_simple/foo_library/foo_library.cc
@@ -1,0 +1,36 @@
+#include "opentelemetry/logs/provider.h"
+
+// Logs
+namespace logs  = opentelemetry::logs;
+namespace nostd = opentelemetry::nostd;
+using opentelemetry::logs::Severity;
+
+namespace
+{
+
+nostd::shared_ptr<logs::Logger> get_logger()
+{
+  auto provider = logs::Provider::GetLoggerProvider();
+  return provider->GetLogger("foo_library");
+}
+
+void f1()
+{
+  get_logger()->Trace("msg from f1");
+}
+
+void f2()
+{
+  get_logger()->Log(Severity::kDebug, "msg from f2");
+
+  f1();
+  f1();
+}
+}  // namespace
+
+void foo_library()
+{
+  get_logger()->Log(Severity::kInfo, "msg from foo_library");
+
+  f2();
+}

--- a/examples/logs_simple/foo_library/foo_library.h
+++ b/examples/logs_simple/foo_library/foo_library.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void foo_library();

--- a/examples/logs_simple/main.cc
+++ b/examples/logs_simple/main.cc
@@ -11,6 +11,7 @@
 
 namespace sdklogs  = opentelemetry::sdk::logs;
 namespace logs_api = opentelemetry::logs;
+namespace nostd = opentelemetry::nostd;
 
 void initLogger()
 {

--- a/examples/logs_simple/main.cc
+++ b/examples/logs_simple/main.cc
@@ -1,0 +1,35 @@
+
+// Sample application
+#include "foo_library/foo_library.h"
+
+// Logs (to OStream)
+#include "opentelemetry/exporters/ostream/log_exporter.h"
+#include "opentelemetry/logs/provider.h"
+#include "opentelemetry/sdk/logs/logger.h"
+#include "opentelemetry/sdk/logs/logger_provider.h"
+#include "opentelemetry/sdk/logs/simple_log_processor.h"
+
+namespace sdklogs  = opentelemetry::sdk::logs;
+namespace logs_api = opentelemetry::logs;
+
+void initLogger()
+{
+  auto exporter =
+      std::unique_ptr<sdklogs::LogExporter>(new opentelemetry::exporter::logs::OStreamLogExporter);
+  auto processor =
+      std::shared_ptr<sdklogs::LogProcessor>(new sdklogs::SimpleLogProcessor(std::move(exporter)));
+  auto sdkProvider = std::shared_ptr<sdklogs::LoggerProvider>(new sdklogs::LoggerProvider());
+  sdkProvider->SetProcessor(processor);
+  auto apiProvider = nostd::shared_ptr<logs_api::LoggerProvider>(sdkProvider);
+  auto provider    = nostd::shared_ptr<logs_api::LoggerProvider>(apiProvider);
+  // Set the global logger provider.
+  logs_api::Provider::SetLoggerProvider(provider);
+}
+
+int main()
+{
+  // Removing this line will leave the default noop LoggerProvider in place.
+  initLogger();
+
+  foo_library();
+}


### PR DESCRIPTION
This shows how logs can be used with the OStream Log Exporter that was built for the logging prototype (in issue # 337). 

In this example, a sample application is instrumented with the Logging API and SDK, and exports logs to `stdout`, which can be seen in console. 

cc @MarkSeufert @alolita 