### PR TITLE
Add CodeQL Security Scan

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,41 @@
+name: "Code Scanning - Action"
+
+on:
+  workflow_dispatch:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '30 1 * * *'
+
+jobs:
+  CodeQL-Build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.3.4
+      with:
+         submodules: 'recursive'
+
+    - name: Setup
+      run: |
+        sudo ./ci/setup_cmake.sh
+        sudo ./ci/setup_ci_environment.sh
+        
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: cpp 
+    
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: "Code Scanning - Action"
+name: "CodeQL Code Scan"
 
 on:
   workflow_dispatch:
@@ -17,25 +17,20 @@ on:
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-latest
-    
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2.3.4
       with:
          submodules: 'recursive'
-
     - name: Setup
       run: |
         sudo ./ci/setup_cmake.sh
         sudo ./ci/setup_ci_environment.sh
-        
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        languages: cpp 
-    
+       languages: cpp
     - name: Autobuild
       uses: github/codeql-action/autobuild@v1
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Increment the:
 
 ## [Unreleased]
 
+* [CI] Add CodeQL security scan CI workflow ([#770](https://github.com/open-telemetry/opentelemetry-cpp/pull/770))
 * [EXPORTER] Populate resource to OTLP proto data ([#758](https://github.com/open-telemetry/opentelemetry-cpp/pull/758))
 
 ## [0.6.0] 2021-05-11


### PR DESCRIPTION
# Motivation
This PR is a follow-up to issue open-telemetry/oteps144

[CodeQL](https://github.com/github/codeql-action) is GitHub's static analysis engine which scans repos for security vulnerabilities. As the project grows and we near GA it might be useful to have a workflow which checks for security vulnerabilities to ensure that every incremental change is following best development practices. Also passing basic security checks will also make sure that there aren't any glaring issues for our users.

## Changes
-  This PR adds [CodeQL](https://github.com/github/codeql-action) security checks to the repository
- After every run the workflow will upload the results to GitHub. 

#### Workflow Triggers
- daily cron job at 1:30 am
- workflow_dispatch (in the case that the maintainers want to trigger a manual security check)

* [X] `CHANGELOG.md` updated for non-trivial changes
* [] Unit tests have been added
* [] Changes in public API reviewed